### PR TITLE
fix: Do not add vote only if the CI User has approved the review

### DIFF
--- a/src/gerrit_ci.ts
+++ b/src/gerrit_ci.ts
@@ -114,7 +114,7 @@ export class GerritCI {
   runSingleChange(gerritId: string, forceExecution = false):
       {message: string, hasError: boolean}|void {
     console.log('Running pipeline for: ' + gerritId);
-    const {ciPatchset, isApproved, patchset} =
+    const {ciPatchset, ciApproved, patchset} =
         this.gerritApiService.getReviewById(gerritId);
 
     // check if need review (never run || diff patchset)
@@ -127,7 +127,7 @@ export class GerritCI {
 
       // is error vote -1, if approved do not vote else +1
       const voteField = hasError ? {vote: -1} : {vote: 1};
-      const vote = isApproved && !hasError ? {} : voteField;
+      const vote = ciApproved && !hasError ? {} : voteField;
 
       if (!this.gerritConfiguration.dryRun) {
         this.gerritApiService.postReviewCommentById(

--- a/tests/gerrit_ci.test.ts
+++ b/tests/gerrit_ci.test.ts
@@ -166,7 +166,7 @@ test('comments and votes -1 when the pipeline fails', () => {
       {message: expectedMessage, vote: -1});
 });
 
-test('Does not add a vote when pipeline succeed on an approved review', () => {
+test('Does not vote when the pipeline succeeds on a CI approved review', () => {
   const gerritCI = new GerritCI({
     repositoryUrl: 'https://gerrit.googlesource.com/project',
     targetBranch: 'master',
@@ -174,7 +174,7 @@ test('Does not add a vote when pipeline succeed on an approved review', () => {
   });
 
   execSyncStub.returns({toString: () => 'yay!'});
-  gerritApiStub.getReviewById.returns({isApproved: true, patchset: '1'});
+  gerritApiStub.getReviewById.returns({ciApproved: true, patchset: '1'});
   gerritCI.runSingleChange('12345');
 
   const expectedMessage = DEFAULT_SUCCESS_MESSAGE('npm run build');


### PR DESCRIPTION
Previously I was only checking whether a CR has been +2ed but that causes an issue when a user has approved it and the CI has last voted -1.

Since it's +2ed, the CI will not add a vote preserving its latest vote (-1) even when the pipeline now succeeds.

The solution is to always add a vote -1/+1 unless the user running the CI (CI user) is the one who has +2ed it. In this case a +1 vote would override the +2 which is something unwanted. Note a CI failure will still add a -1 to ensure the error is noticed.